### PR TITLE
Provide entire pages as context

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://github.com/MomirMilutinovic/smartcat-qna-weaviate/assets/40830508/197121
 # smartcat-qna-weaviate
 A RAG chatbot that answers questions about [SmartCat](https://smartcat.io), an AI company based in Novi Sad, Serbia.
 
-The chatbot bases its answers on the articles on the company's website. The pages are scraped, chunked and stored in a [Weaviate](https://github.com/weaviate/weaviate) vector database beforehand. The pages are fed to a [Cohere](https://cohere.com) LLM to generate the answers to the questions.
+The chatbot bases its answers on articles scraped from SmartCat's website. The web pages are chunked and stored in a [Weaviate](https://github.com/weaviate/weaviate) vector database. Pages relevant to the user's question are fetched based on a hybrid search over chunks and entire pages. The resulting pages are fed to a [Cohere](https://cohere.com) LLM to generate an answer to the user's question.
 
 ## Prerequisites
 - Docker 
@@ -36,7 +36,7 @@ pip install -r requirements.txt
 export COHERE_API_KEY=<your_cohere_api_key>
 ```
 ## Usage instructions
-1. Start up Weaviate: `docker compose up -d`. Once completed, Weaviate is running on [`http://localhost:9999`]().
+1. Start up Weaviate: `docker compose up -d`. Once completed, Weaviate will run on [`http://localhost:9999`]().
 2. Download the pages from  [SmartCat](https://smartcat.io)'s website:
 ```
 scrapy runspider src/ingestion/smartcat_spider.py -O articles.json
@@ -45,12 +45,7 @@ scrapy runspider src/ingestion/smartcat_spider.py -O articles.json
 4. Start the Streamlit app: `streamlit run src/streamlit/app.py`. The app should be running on [`http://localhost:8501`]() once it starts up.
 
 ## Limitations
-- Even though the chatbot queries the Weaviate database before it generates its answer, it may include inaccurate information in its answers.
-- The chatbot may disregard instructions in its system prompt in longer conversations
-
-These problems likely stem from the way pages are stored in the database and presented to the LLM. The LLM receives chunks of possibly disparate pages. Firstly, these chunks may contain insufficient information. Secondly, they could also confuse the LLM as they are not cohesive.
-
-Fetching entire pages may improve the chatbot's performance.
+Parts of the chatbot's answers may be inaccurate.
 
 ## Disclaimer
 This project is not affiliated with SmartCat in any way. It should not be used as a source of truth for any information about SmartCat.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 
 
-
-https://github.com/MomirMilutinovic/smartcat-qna-weaviate/assets/40830508/fc7b0b52-d174-418e-848c-bade5c06abe0
-
+https://github.com/MomirMilutinovic/smartcat-qna-weaviate/assets/40830508/197121dc-15fa-4232-9af9-a9a20387509d
 
 
 # smartcat-qna-weaviate
-A RAG chatbot that answers questions about [SmartCat](https://smartcat.io).
+A RAG chatbot that answers questions about [SmartCat](https://smartcat.io), an AI company based in Novi Sad, Serbia.
 
 The chatbot bases its answers on the articles on the company's website. The pages are scraped, chunked and stored in a [Weaviate](https://github.com/weaviate/weaviate) vector database beforehand. The pages are fed to a [Cohere](https://cohere.com) LLM to generate the answers to the questions.
 

--- a/src/ingestion/smartcat_spider.py
+++ b/src/ingestion/smartcat_spider.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import scrapy
 import re
+import uuid
 from bs4 import BeautifulSoup
 
 class SmartcatSpider(scrapy.Spider):
@@ -27,6 +28,7 @@ class SmartcatSpider(scrapy.Spider):
         text = soup.find('div', {'id': 'page'}).get_text()
         sections = [section.get_text() for section in soup.find_all('section')]
         yield {
+            'doc_id': str(uuid.uuid4()),
             'url': response.url,
             'title': response.css('title::text').re('(.*) - SmartCat')[0],
             'text': text,

--- a/src/ingestion/upload_data.py
+++ b/src/ingestion/upload_data.py
@@ -80,7 +80,8 @@ if __name__ == '__main__':
         properties=[
             wvcc.Property(name="title", data_type=wvcc.DataType.TEXT),
             wvcc.Property(name="chunk", data_type=wvcc.DataType.TEXT),
-            wvcc.Property(name="chunk_index", data_type=wvcc.DataType.INT, skip_vectorization=True)
+            wvcc.Property(name="chunk_index", data_type=wvcc.DataType.INT, skip_vectorization=True),
+            wvcc.Property(name="doc_id", data_type=wvcc.DataType.UUID, skip_vectorization=True)
         ]
     )
 

--- a/src/ingestion/upload_data.py
+++ b/src/ingestion/upload_data.py
@@ -89,6 +89,7 @@ if __name__ == '__main__':
 
     chunked_articles = [
         {
+            'doc_id': article['doc_id'],
             'title': article['title'],
             'chunk': text_chunk,
             'chunk_index': chunk_i

--- a/src/question_answering/question_answering.py
+++ b/src/question_answering/question_answering.py
@@ -57,7 +57,7 @@ retriever = ParentDocumentRetriever(
     child_splitter=placholder_splitter,
 )
 
-llm = Cohere(model="command", max_tokens=4096, temperature=0)
+llm = Cohere(model="command-nightly", max_tokens=8192, temperature=0)
 
 memory = ConversationBufferMemory(
     memory_key="chat_history", return_messages=True)

--- a/src/question_answering/question_answering.py
+++ b/src/question_answering/question_answering.py
@@ -25,6 +25,8 @@ When talking about services, first explain in detail what those services are, be
 When asked about a specific open job position, provide a detailed answer that includes a high level description, the requirements, technology stack, and benefits, in that order.
 When asked about all job positions, provide a list of all open job positions and do not go into the details of each job position.
 At the end of each answer, tell the user that it's best to verify the most up-to-date information on SmartCat's official website.
+If a job does not mention a specific number of years of experience, don't make up a number. Just say that you need extensive experience with what is mentioned in the job posting.
+When listing technologies, list them in the order they are mentioned in the job posting. Only list technologies that are mentioned in the job posting. Don't make up technologies.
 Question: {question}
 =========
 {context}


### PR DESCRIPTION
For several use cases, such as summarizing job postings, the LLM needs more context than a ~100-word chunk provides.
To solve this issue, this PR changes the retriever of the `ConversationalRetrieverChain` for one that fetches whole pages instead of chunks.
Additionally, this PR implements hybrid search to improve the quality of answers for more specific queries.